### PR TITLE
Updated dependencies and allow falafel-options pass through.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 /// <reference path="./typings/tsd.d.ts"/>
 'use strict';
-var through = require('through2');
-var falafel = require('falafel');
+Object.defineProperty(exports, "__esModule", { value: true });
+var through = require("through2");
+var falafel = require("falafel");
 function setDefaultValue(opts) {
     if (typeof opts.ignore === 'undefined') {
         opts.ignore = /^\$/;
@@ -31,6 +32,12 @@ function setDefaultValue(opts) {
             { pattern: /Directive$/, func: 'Directive', removePattern: true, firstLowerCase: true }
         ];
     }
+    if (typeof opts.falafelOptions === 'undefined') {
+        opts.falafelOptions = {
+            sourceType: 'script',
+            tolerant: true
+        };
+    }
 }
 module.exports = function angularify(opts) {
     opts = opts || {};
@@ -38,6 +45,7 @@ module.exports = function angularify(opts) {
     // creating a stream through which each file will pass
     var stream = through.obj(function (file, enc, cb) {
         if (file.isNull()) {
+            // do nothing
         }
         if (file.isBuffer()) {
             var contents = file.contents.toString();
@@ -51,7 +59,7 @@ module.exports = function angularify(opts) {
     return stream;
 };
 function transform(contents, opts) {
-    return falafel(contents, { tolerant: true }, function (node) {
+    return falafel(contents, opts.falafelOptions, function (node) {
         findClassDeclaration(node, opts);
     }).toString();
 }

--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,11 @@ interface Options {
   decoratorPatterns?: DecoratorPattern[];
   decoratorModuleName?: string;
   decorator?: boolean;
+  falafelOptions?: {
+    ecmaVersion?: 3 | 5 | 6 | 7 | 8;
+    sourceType?: 'script' | 'module';
+    tolerant: boolean;
+  };
 }
 
 function setDefaultValue(opts: Options) {
@@ -58,6 +63,12 @@ function setDefaultValue(opts: Options) {
     ];
   }
 
+  if (typeof opts.falafelOptions === 'undefined') {
+    opts.falafelOptions = {
+        sourceType: 'script',
+        tolerant: true
+    };
+  }
 }
 
 module.exports = function angularify(opts: Options) {
@@ -120,7 +131,7 @@ interface DecoratorBlock{
 }
 
 function transform(contents: string, opts: Options): string {
-  return falafel(contents, { tolerant: true }, function(node: Node) {
+  return falafel(contents, opts.falafelOptions, function(node: Node) {
     findClassDeclaration(node, opts);
   }).toString();
 }
@@ -235,7 +246,7 @@ function addAngularModule(node:Node, decl:Declaration, opts:Options, ptn:Pattern
   }
 
   function createModule() {
-    constructorParams.push(`function(){return new (Function.prototype.bind.apply(${className},[null].concat(Array.prototype.slice.call(arguments))));}`);    
+    constructorParams.push(`function(){return new (Function.prototype.bind.apply(${className},[null].concat(Array.prototype.slice.call(arguments))));}`);
     var source = '';
     source += `angular.module('${moduleName}')`;
     source += `.${type}('${conponentName}',[${constructorParams.join('\,')}]);`;

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "homepage": "https://github.com/takeshi/gulp-typescript-angular",
   "dependencies": {
-    "falafel": "^1.0.1",
-    "gulp": "^3.8.11",
-    "gulp-typescript": "^2.5.0",
-    "through2": "^0.6.3"
+    "falafel": "^2.1.0",
+    "gulp": "^3.9.1",
+    "gulp-typescript": "^3.1.6",
+    "through2": "^2.0.3"
   }
 }


### PR DESCRIPTION
The newer falafel version and the pass through of options to it, allow for better configuration. E.g. `{sourceType: "module"}` allows one to configure TypeScript to output ES6 modules.